### PR TITLE
PAM-1736 Lagt til oppfølgingsinfo i avro-skjemaet

### DIFF
--- a/src/main/resources/avro/CvEvent.avsc
+++ b/src/main/resources/avro/CvEvent.avsc
@@ -27,6 +27,12 @@
     {"name": "kommunenr", "type": ["null", "int"]},
     {"name": "disponererBil", "type": ["null", "boolean"]},
     {"name": "tidsstempel", "type": "string"},
+    {"name": "orgenhet", "type": ["null", "string"], "default": null },
+    {"name": "kvalifiseringsgruppekode", "type": ["null", "string"], "default": null },
+    {"name": "frkas", "type": "boolean" },
+    {"name": "imatc", "type": "boolean" },
+    {"name": "frKode", "type": ["null", "string"], "default": null },
+    {"name": "erDoed", "type": ["null", "boolean"], "default": null },
     {"name": "utdanning", "type":
       {
         "type": "array", "items":


### PR DESCRIPTION

Sakset fra Jira:
(PS. formidlingsgruppekode er med i skjemaet allerede.. erDoed tok jeg med fordi vi trenger den også.)
---
Avro-skjemaet no.nav.arbeid.cv.avro:cv-event må utvides med oppfølgingsdata fra Arena. 
formidlingsgruppekode (string/eum)
FRKAS (boolean)
IMATC (boolean)
frKode (string/enum)
kvalifiseringsgruppekode (string/enum)
orgenhet (string)
Jeg er ikke helt sikker på om vi bør utvide skjemaet og beholde samme topic, eller om vi ifm denne utvidelsen bør ta i bruk et nytt topic (v2).. Det må vurderes av den som gjør oppgaven.